### PR TITLE
dsn parts changed to uppercase

### DIFF
--- a/src/Database/Connectors/ODBCConnector.php
+++ b/src/Database/Connectors/ODBCConnector.php
@@ -18,10 +18,10 @@ class ODBCConnector extends DB2Connector
     {
         $dsnParts = [
             'odbc:DRIVER=%s',
-            'System=%s',
-            'Database=%s',
-            'UserID=%s',
-            'Password=%s',
+            'SYSTEM=%s',
+            'DATABASE=%s',
+            'USERID=%s',
+            'PASSWORD=%s',
         ];
 
         $dsnConfig = [

--- a/src/Database/Connectors/ODBCZOSConnector.php
+++ b/src/Database/Connectors/ODBCZOSConnector.php
@@ -18,12 +18,12 @@ class ODBCZOSConnector extends ODBCConnector
     {
         $dsnParts = [
             'odbc:DRIVER=%s',
-            'Database=%s',
-            'Hostname=%s',
-            'Port=%s',
-            'Protocol=TCPIP',
-            'Uid=%s',
-            'Pwd=%s',
+            'DATABASE=%s',
+            'HOSTNAME=%s',
+            'PORT=%s',
+            'PROTOCOL=TCPIP',
+            'UID=%s',
+            'PWD=%s',
             '', // Just to add a semicolon to the end of string
         ];
 


### PR DESCRIPTION
Recently i tried to update PHP version in my application (8.1.6->8.3) and received PDOException:

SQLSTATE[08001] SQLDriverConnect: -30082 [IBM][CLI Driver] SQL30082N Security processing failed with reason "24" ("USERNAME AND/OR PASSWORD INVALID"). SQLSTATE=08001

Finally found that making dsn parts in ODBCConnector class uppercase resolved problem.
Making those parts uppercase didn't brake app version working on PHP 8.1.6, so i assume this change shouldn't brake anything.